### PR TITLE
Update CLIP Text Encode node documentation

### DIFF
--- a/comfyui_embedded_docs/docs/ClipTextEncode/en.md
+++ b/comfyui_embedded_docs/docs/ClipTextEncode/en.md
@@ -1,61 +1,65 @@
-`CLIP Text Encode (CLIPTextEncode)` acts like a translator, converting your creative text descriptions into a special "language" that AI can understand, helping the AI accurately interpret what kind of image you want to create.
+`CLIP Text Encode (CLIPTextEncode)` acts as a translator, converting your text descriptions into a format that AI can understand. This helps the AI interpret your input and generate the desired image.
 
-Imagine communicating with a foreign artist - you need a translator to help accurately convey the artwork you want. This node acts as that translator, using the CLIP model (an AI model trained on vast amounts of image-text pairs) to understand your text descriptions and convert them into "instructions" that the AI art model can understand.
+Think of it as communicating with an artist who speaks a different language. The CLIP model, trained on vast image-text pairs, bridges this gap by converting your descriptions into "instructions" that the AI model can follow.
 
 ## Inputs
 
 | Parameter | Data Type | Input Method | Default | Range | Description |
 |-----------|-----------|--------------|---------|--------|-------------|
-| text | STRING | Text Input | Empty | Any text | Like detailed instructions to an artist, enter your image description here. Supports multi-line text for detailed descriptions. |
-| clip | CLIP | Model Selection | None | Loaded CLIP models | Like choosing a specific translator, different CLIP models are like different translators with slightly different understandings of artistic styles. |
+| text | STRING | Text Input | Empty | Any text | Enter the description (prompt) for the image you want to create. Supports multi-line input for detailed descriptions. |
+| clip | CLIP | Model Selection | None | Loaded CLIP models | Select the CLIP model to use when translating your description into instructions for the AI model. |
 
 ## Outputs
 
 | Output Name | Data Type | Description |
 |-------------|-----------|-------------|
-| CONDITIONING | CONDITIONING | These are the translated "painting instructions" containing detailed creative guidance that the AI model can understand. These instructions tell the AI model how to create an image matching your description. |
+| CONDITIONING | CONDITIONING | The processed "instructions" of your description that guide the AI model when generating an image. |
 
-## Usage Tips
+## Prompt Features
 
-1. **Basic Text Prompt Usage**
-   - Write detailed descriptions like you're writing a short essay
-   - More specific descriptions lead to more accurate results
-   - Use English commas to separate different descriptive elements
+### Embedding Models
 
-2. **Special Feature: Using Embedding Models**
-   - Embedding models are like preset art style packages that can quickly apply specific artistic effects
-   - Currently supports .safetensors, .pt, and .bin file formats, and you don't necessarily need to use the complete model name
-   - How to use:
-     1. Place the embedding model file (in .pt format) in the `ComfyUI/models/embeddings` folder
-     2. Use `embedding:model_name` in your text
-     Example: If you have a model called `EasyNegative.pt`, you can use it like this:
+Embedding models allow you to apply specific artistic effects or styles. Supported formats include `.safetensors`, `.pt`, and `.bin`. To use an embedding model:
 
-     ```
-     a beautiful landscape, embedding:EasyNegative, high quality
-     ```
+1. Place the file in the `ComfyUI/models/embeddings` folder.
+2. Reference it in your text using `embedding:model_name`.
 
-3. **Prompt Weight Adjustment**
-   - Use parentheses to adjust the importance of certain descriptions
-   - For example: `(beautiful:1.2)` will make the "beautiful" feature more prominent
-   - Regular parentheses `()` have a default weight of 1.1
-   - Use keyboard shortcuts `ctrl + up/down arrow` to quickly adjust weights
-   - The weight adjustment step size can be modified in settings
+Example: If you have a model named `EasyNegative.pt` in your `ComfyUI/models/embeddings` folder, then you can use it like this:
 
-4. **Wildcard/Dynamic Prompts**
-   - You can use `{day|night|morning}` for wildcard/dynamic prompts. With this syntax, `{red|green|blue}` will be randomly replaced by either `red`, `green`, or `blue` by the frontend every time you queue the prompt.
-   - To use `{}` characters in your actual prompt, escape them like: `\{` or `\}`.
+```
+worst quality, embedding:EasyNegative, bad quality
+```
 
-5. **Comments in Prompts**
-   - The prompt also support C-style comments:
-     - Use `//` to comment out a whole line
-     - Use `/* */` to comment out a section
-     - Example:
-     ```
-     // This line is excluded from the prompt
-     a beautiful landscape, /* this is also excluded */ high quality
-     ```
+**IMPORTANT**: When using embedding models, verify that the file name matches and is compatible with your model's architecture. For example an embedding designed for SD1.5 will not work correctly for a SDXL model.
 
-6. **Important Notes**
-   - Ensure the CLIP model is properly loaded
-   - Use positive and clear text descriptions
-   - When using embedding models, make sure the file name is correct and compatible with your current main model's architecture
+### Prompt Weight Adjustment
+
+You can adjust the importance of certain parts of your description using parentheses. For example:
+
+- `(beautiful:1.2)` increases the weight of "beautiful".
+- `(beautiful:0.8)` decrease the weight of "beautiful".
+- Plain parentheses `(beautiful)` will apply a default weight of 1.1.
+
+You can use the keyboard shortcuts `ctrl + up/down arrow` to quickly adjust weights. The weight adjustment step size can be modified in the settings.
+
+If you want to include literal parentheses in your prompt without changing the weight, you can escape them using a backslash e.g. `\(word\)`.
+
+### Wildcard/Dynamic Prompts
+
+Use `{}` to create dynamic prompts. For example, `{day|night|morning}` will randomly select one option each time the prompt is processed.
+
+If you want to include literal curly braces in your prompt without triggering dynamic behavior, you can escape them using a backslash e.g. `\{word\}`.
+
+### Comments in Prompts
+
+You can add comments that are excluded from the prompt by using:
+
+- `//` to comment out a single line.
+- `/* */` to comment out a section or multiple lines.
+
+Example:
+
+```
+// this line is excluded from the prompt.
+a beautiful landscape, /* this part is ignored */ high quality
+```


### PR DESCRIPTION
This PR adds documentation for wildcards and comments to the CLIP Text Encode node as described in the main ComfyUI README [here](https://github.com/comfyanonymous/ComfyUI?tab=readme-ov-file#notes).

**NOTE**: I made two commits for this: the first is a minimal commit that adds wildcards and comments to the existing documentation. The second commit is a more opinionated refactor of the CLIP Text Encode documentation. Please let me know if you don't like the larger refactor, and I'll revert it to the minimal commit instead.

---

While adding wildcards and comments, I noticed the overall documentation could be improved, so I reviewed all of it. The refactor brings several improvements beyond adding the missing features; here are some of the main ones:

- Reduced the overreliance on bullet points, which previously made the text read awkwardly.
- Reduced overall "fluff" words (e.g., "like") to make the text more concise and professional.
- Clarified that weights can be reduced by using values below 1.0.
- Added instructions for including literal `()` in prompts.
- Clarified that "prompt" corresponds to "description" in the input section for beginners unfamiliar with the terminology.
- Removed general tips for writing prompts because best practices depend on the model (for example, some models work better with tag-based prompting).
- Moved the "important" notes about embeddings into the embedding section to make them easier to find when skimming.
- The `EasyNegative` embedding is supposed to be used in the negative prompt, so I made the surrounding words in the example negative as well.